### PR TITLE
Fix bounding box issues

### DIFF
--- a/src/main/native/cpp/rubik_jni.cpp
+++ b/src/main/native/cpp/rubik_jni.cpp
@@ -577,15 +577,14 @@ Java_org_photonvision_rubik_RubikJNI_detect
     uint8_t raw_y_2_u8 = boxesData[i * 4 + 3];
 
     // Use proper dequantization for bbox coordinates (like we do for scores)
-    float x1 =
-        get_dequant_value(&raw_x_1_u8, kTfLiteUInt8, 0,
-                          boxesParams.zero_point, boxesParams.scale);
+    float x1 = get_dequant_value(&raw_x_1_u8, kTfLiteUInt8, 0,
+                                 boxesParams.zero_point, boxesParams.scale);
     float y1 = get_dequant_value(&raw_y_1_u8, kTfLiteUInt8, 0,
-                          boxesParams.zero_point, boxesParams.scale);
+                                 boxesParams.zero_point, boxesParams.scale);
     float x2 = get_dequant_value(&raw_x_2_u8, kTfLiteUInt8, 0,
-                                    boxesParams.zero_point, boxesParams.scale);
+                                 boxesParams.zero_point, boxesParams.scale);
     float y2 = get_dequant_value(&raw_y_2_u8, kTfLiteUInt8, 0,
-                                     boxesParams.zero_point, boxesParams.scale);
+                                 boxesParams.zero_point, boxesParams.scale);
 
     float clamped_x1 =
         std::max(0.0f, std::min(x1, static_cast<float>(input_img->cols)));


### PR DESCRIPTION
closes #12

Previously, we assumed the tensor returned a center and size. We've since discovered that it returns top_left and bottom_right coords.

New:
![bus_results](https://github.com/user-attachments/assets/b90e3a8c-7d68-461b-a4fa-30445f21906f)

Old:
![bus_with_results](https://github.com/user-attachments/assets/3d2897fb-f65b-44ab-aa0d-3c819ac67cce)