### PR TITLE
build: Fix version script

### DIFF
--- a/versioningHelper.gradle
+++ b/versioningHelper.gradle
@@ -8,11 +8,8 @@ gradle.allprojects {
         def stdout = new ByteArrayOutputStream()
         String tagIsh
         try {
-            project.exec {
-                commandLine 'git', 'describe', '--tags', "--match=v*"
-                standardOutput = stdout
-            }
-            tagIsh = stdout.toString().trim().toLowerCase()
+            def line = "git describe --tags --match=v*".execute().text.trim().readLines().last()
+            tagIsh = line.toString().trim().toLowerCase()
         } catch (Exception e) {
             tagIsh = "dev-Unknown"
         }


### PR DESCRIPTION
project.exec is deprecated in Gradle 9 and doesn't work in some cases, replacing it with groovy's execute function works