### PR TITLE
ci: Fix Publish type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Publish
       run: |
-        ./gradlew build ${{ (startsWith(github.event_name, 'push') && 'publish') || '' }} -PArchOverride=${{ matrix.platform }} -PPublishType=${{ matrix.build-type }}-${{ matrix.platform }} -x check
+        ./gradlew build ${{ (startsWith(github.event_name, 'push') && 'publish') || '' }} -PArchOverride=${{ matrix.platform }} -PPublishType=${{ matrix.build-type != 'Release' && matrix.build-type || '' }} -x check
       env:
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
 


### PR DESCRIPTION
When I refactored the actions matrix to be clearer I also broke the publishing type. Based off of the last version we want an empty string for release and to attach the build type for other platforms. Based on the way we pull this in PhotonVision the release build is the only one that expects a specific format so the slight changes for other platforms shouldn't be a problem. It seems non trivial to make PhotonVision pull in the other platforms as needed as the build type being used for native binaries isn't easily accessible where we pull in this JNI repo.