### PR TITLE
Fix memleak and benchmark tests

### DIFF
--- a/.github/workflows/hand-tests.yml
+++ b/.github/workflows/hand-tests.yml
@@ -1,0 +1,64 @@
+name: Run memleak and benchmark tests
+
+on:
+  push:
+    branches: [ "main" ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v4
+  build:
+    needs: [validation]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build-type: Release
+            os: ubuntu-24.04-arm
+            platform: "linuxarm64"
+          - build-type: Release
+            os: ubuntu-24.04
+            platform: "linuxx86-64"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Fetch tags
+      run: git fetch --tags --force
+    - run: git describe --tags
+
+    - name: Install Java 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: 25
+        distribution: temurin
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential default-jdk openjdk-25-jdk ninja-build libasan8
+
+    - name: Build native code
+      run: |
+        cmake --preset with-sccache -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DOPENCV_ARCH=${{ matrix.platform }}
+        cmake --build cmake_build --target install -- -j 4
+
+    - name: Run memleak test
+      run: ./gradlew build -PmemLeakTestIterations=10
+
+    - name: Run benchmark test
+      run: ./gradlew build -PbenchmarkIterations=10

--- a/src/test/java/org/photonvision/tflite/TFLiteTest.java
+++ b/src/test/java/org/photonvision/tflite/TFLiteTest.java
@@ -153,7 +153,11 @@ public class TFLiteTest {
         System.out.println(Core.OpenCLApiCallError);
 
         System.out.println("Loading tflite_jni");
-        System.load("/home/photon/tflite_jni/cmake_build/libtflite_jni.so");
+        Path localSo = Path.of("cmake_build", "lib", "libtflite_jni.so").toAbsolutePath();
+        Assumptions.assumeTrue(
+                Files.exists(localSo),
+                "Native library not found at " + localSo + " (run the native build first)");
+        System.load(localSo.toString());
 
         int numRuns = Integer.parseInt(System.getProperty("memLeakTestIterations"));
 
@@ -166,7 +170,7 @@ public class TFLiteTest {
             // Create a TFLite detector instance
             long ptr =
                     TFLiteJNI.create(
-                            "src/test/resources/models/yolov8nCoco.tflite", 0, TFLiteSource.CPU.value());
+                            "src/test/resources/models/yolov8nCoco.tflite", 1, TFLiteSource.CPU.value());
 
             if (ptr == 0) {
                 throw new RuntimeException("Failed to create TFLite detector");
@@ -198,7 +202,11 @@ public class TFLiteTest {
         System.out.println(Core.OpenCLApiCallError);
 
         System.out.println("Loading tflite_jni");
-        System.load("/home/photon/tflite_jni/cmake_build/libtflite_jni.so");
+        Path localSo = Path.of("cmake_build", "lib", "libtflite_jni.so").toAbsolutePath();
+        Assumptions.assumeTrue(
+                Files.exists(localSo),
+                "Native library not found at " + localSo + " (run the native build first)");
+        System.load(localSo.toString());
 
         System.out.println("Loading bus");
         Mat img = Imgcodecs.imread("src/test/resources/images/bus.jpg");


### PR DESCRIPTION
The loading break was from my PR and the model version was preexisting. I've also added a CI job specifically for them to ensure we don't break these in the future, even though the results need manual inspection at least we know they will run.