### PR TITLE
fix: enable sccache GHA cache backend

### DIFF
--- a/.github/workflows/hand-tests.yml
+++ b/.github/workflows/hand-tests.yml
@@ -29,6 +29,8 @@ jobs:
             platform: "linuxx86-64"
 
     runs-on: ${{ matrix.os }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
             platform: "linuxx86-64"
 
     runs-on: ${{ matrix.os }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
## Summary

This PR enables sccache's GitHub Actions cache backend by setting `SCCACHE_GHA_ENABLED: "true"` on the `build` jobs in both workflow files.

## Problem

sccache was running in local-only mode because no remote cache backend was configured. Since GitHub Actions runners are ephemeral, the local cache was created fresh and destroyed on every run — zero cache hits.

## Fix

As documented in the [mozilla-actions/sccache-action README](https://github.com/mozilla-actions/sccache-action#cc-code), C/C++ projects need `SCCACHE_GHA_ENABLED: "true"` set as an environment variable for sccache to use the GitHub Actions cache API as its backend. The CMake presets already had `CMAKE_C_COMPILER_LAUNCHER=sccache` and `CMAKE_CXX_COMPILER_LAUNCHER=sccache`, so that part was correct.

This change was generated with AI assistance.