### PR TITLE
ci: only publish release builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,7 @@ jobs:
       run: ./gradlew build
 
     - name: Publish
+      if: ${{ matrix.build-type }} == Release
       run: |
         ./gradlew build ${{ (startsWith(github.event_name, 'push') && 'publish') || '' }} -PArchOverride=${{ matrix.platform }} -PPublishType=${{ matrix.build-type != 'Release' && matrix.build-type || '' }} -x check
       env:


### PR DESCRIPTION
This should help with the space issues we are encountering on the server.