### PR TITLE
Fixup publishing release versions only

### DIFF
--- a/.github/workflows/hand-tests.yml
+++ b/.github/workflows/hand-tests.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validation:
     name: "Validation"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       run: ./gradlew build
 
     - name: Publish
-      if: ${{ matrix.build-type }} == Release
+      if: matrix.build-type  == 'Release'
       run: |
         ./gradlew build ${{ (startsWith(github.event_name, 'push') && 'publish') || '' }} -PArchOverride=${{ matrix.platform }} -PPublishType=${{ matrix.build-type != 'Release' && matrix.build-type || '' }} -x check
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validation:
     name: "Validation"


### PR DESCRIPTION
Fix the logic in the workflow so that we only publish release versions to our maven, and add concurrency blocks so that subsequent runs cancel.